### PR TITLE
autokey.sh: load fallback settings from /etc/default/keyboard

### DIFF
--- a/lxsession/autokey.sh
+++ b/lxsession/autokey.sh
@@ -6,9 +6,14 @@ else
   if lsusb -d 1c4f:0027; then
 	echo "Pi Keyboard"
 	setxkbmap us
-  fi
-  if lsusb -d 1c4f:0016; then
+  elif lsusb -d 1c4f:0016; then
 	echo "Black keyboard"
 	setxkbmap gb
+  else
+	# /etc/default/keyboard contains system-wide default keyboard
+	# settings, but for some reason those don't seem to get loaded
+	# automatically during the X session setup. Running setxkbmap without
+	# arguments loads the default settings, so let's do that here.
+	setxkbmap
   fi
 fi


### PR DESCRIPTION
Debian stores the system-wide keyboard settings in
/etc/default/keyboard. I don't know what component is usually supposed
to load the settings during the X session startup, but it seems that on
Raspbian nothing loads those settings.

I used "dpkg-reconfigure keyboard-configuration" to set my keyboard
layout to Finnish, but that made no difference. Running
"setxkbkeymap -query" showed that setxkbkeymap thought that the layout
was Finnish, yet trying to write something showed that US English keymap
was what the X server actually used. Running setxkbkeymap without
arguments loaded the correct configuration.

autokey.sh seems to be a somewhat appropriate place to fix this issue.
It would be nice to know how Debian usually does this, though. I
couldn't find anything under /etc or /usr on my regular Debian system
that would load /etc/default/keyboard. (I haven't tested if this is
actually broken on Debian too, but I'd be surprised if that was the
case.)
