### PR TITLE
autokey.sh: load fallback settings from /etc/default/keyboard

### DIFF
--- a/etc/xdg/lxsession/LXDE-pi/autokey.sh
+++ b/etc/xdg/lxsession/LXDE-pi/autokey.sh
@@ -6,9 +6,15 @@ else
   if lsusb -d 1c4f:0027; then
 	echo "Pi Keyboard"
 	setxkbmap us
-  fi
-  if lsusb -d 1c4f:0016; then
+  elif lsusb -d 1c4f:0016; then
 	echo "Black keyboard"
 	setxkbmap gb
+  else
+	# /etc/default/keyboard contains system-wide default keyboard
+	# settings, but for some reason those don't seem to get loaded
+	# automatically during the X session setup (lightdm bug?).
+	# Running setxkbmap without arguments loads the default settings,
+	# so let's do that here.
+	setxkbmap
   fi
 fi


### PR DESCRIPTION
When setting up a new Raspbian installation, I used "dpkg-reconfigure
keyboard-configuration" to set my keyboard layout to Finnish, but that
made no difference. Running "setxkbmap -query" showed that setxkbmap
thought that the layout was Finnish, yet trying to write something
showed that US English keymap was what the X server actually used.
Running setxkbkeymap without arguments loaded the correct configuration.

Debian stores the system-wide keyboard settings in
/etc/default/keyboard. I have Debian on my laptop, and there I think gdm
calls setxkbmap or similar to load those settings, and when gdm starts a
new login session, gdm forwards the settings from the gdm session to the
new login session. lightdm on Raspbian doesn't seem to do that, so the
settings in /etc/default/keyboard don't have effect. Perhaps this should
be fixed in lightdm, but I found autokey.sh that already does some
keyboard layout initialization, so I figured that it wouldn't cause much
harm to fix this there.