### PR TITLE
[lxde-pi-rc.xml] Add keybindings for audio volume keys

### DIFF
--- a/etc/xdg/openbox/lxde-pi-rc.xml
+++ b/etc/xdg/openbox/lxde-pi-rc.xml
@@ -321,6 +321,22 @@
         <command>lxtask</command>
       </action>
     </keybind>
+    <!-- Keybindings for audio volume media keys -->
+    <keybind key="XF86AudioRaiseVolume">
+      <action name="Execute">
+        <command>amixer set PCM 250+ unmute</command>
+      </action>
+    </keybind>
+    <keybind key="XF86AudioLowerVolume">
+      <action name="Execute">
+        <command>amixer set PCM 250- unmute</command>
+      </action>
+    </keybind>
+    <keybind key="XF86AudioMute">
+      <action name="Execute">
+        <command>amixer set PCM toggle</command>
+      </action>
+    </keybind>
   </keyboard>
   <mouse>
     <dragThreshold>8</dragThreshold>


### PR DESCRIPTION
It would be nice if Raspbian made use of the volume keys on most keyboards, as those keys are currently unbound. By binding them, it would lessen the need for users to use additional audio control equipment, such as needing a separate remote just for controlling TV volume in addition to a wireless keyboard.

(This PR builds on a [YouTube video](https://www.youtube.com/watch?v=1GLRcJZjrWI) for binding the volume up/down keys, adding the mute key and unmuting when the volume is increased or decreased.)