### PR TITLE
Fix a couple of subtle bugs in the postinst script

### DIFF
--- a/debian/raspberrypi-ui-mods.postinst
+++ b/debian/raspberrypi-ui-mods.postinst
@@ -13,7 +13,7 @@ case "${1}" in
         if grep -q $USHELL /etc/shells ; then
           USER=$(echo $line | cut -d: -f1)
           HOME_DIR=$(echo $line | cut -d: -f6)/
-          GROUP=$(getent group $USER | cut -d: -f1)
+          GROUP=$(getent group $(getent passwd $USER | cut -d: -f4) | cut -d: -f1)
           BACKUP_DIR=${HOME_DIR}oldconffiles
           CONF_DIR=${HOME_DIR}.config
           THEME_DIR=${HOME_DIR}.themes
@@ -77,6 +77,7 @@ case "${1}" in
           if [ -n "${CHANGED_FILES}" ]; then
             echo "Backing up old config files..."
             rm -rf ${BACKUP_DIR}
+            CHANGED=0
             for file in $CHANGED_FILES; do
               if [ -e $file ]; then
                 CHANGED=1


### PR DESCRIPTION
There's a couple of rather subtle bugs in the [postinst script](https://github.com/RPi-Distro/raspberrypi-ui-mods/blob/master/debian/raspberrypi-ui-mods.postinst) which I've just run into during an upgrade. I should note that my setup is fairly obscure (my Pis authenticate with a central LDAP server via sssd) and thus it's rather unlikely many people will run into this, so this is definitely low priority, but I think they're simple enough to be worth fixing just in case:

* The `CHANGED` variable is set to 1 on line 82, and this is then checked on line 89 ... but it's never reset back to 0 anywhere else in the loop. If you happen to have users returned by `getent passwd` which have valid login shells, but only *some* of those users have existing home-directories on the Pi then the following series of events are possible:

  1. The script loops around over a bunch of users without existing home-dirs. The test on line 81 (file existence) correctly excludes each of these users so CHANGED remains unset
  2. Eventually the script reaches a user with a home-dir that exists, CHANGED is set to 1 and the files are backed up.
  3. On the next go round the loop the script encounters another user whose home-dir doesn't exist. But CHANGED is still 1, so after line 89 a chown is attempted on a non-existent directory and the script blows up with an error (because of the `set -e` at the top).
  4. Consequently `apt` exits in the middle of the upgrade leaving the user scratching their head (as I make home-dirs on initial login with pam_mkhomedir, and there's plenty of users in LDAP that have never logged into the Pi, this is unfortunately what happened to me :).

* The other bug is that on line 16 the script assumes the existence of a group with the same name as the user. This is certainly common in most distros, and extremely common in the case of users with valid login shells but it's not *guaranteed* (I've got two special cases in my LDAP dir of users with valid login shells but without equivalently named groups - due to some corporate software that demanded such a weird setup). Instead of `GROUP=$(getent group $USER | cut -d: -f1)` I'd suggest this ought to be `GROUP=$(getent group $(getent passwd $USER | cut -d: -f4) | cut -d: -f1)` which looks up the primary gid of the user and uses that with getent group instead.