### PR TITLE
Allow extension of XDG_DATA_DIRS

### DIFF
--- a/usr/bin/startlxde-pi
+++ b/usr/bin/startlxde-pi
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if ! grep -q 'Raspberry Pi' /proc/device-tree/model || (grep -q okay /proc/device-tree/soc/v3d@7ec00000/status 2> /dev/null || grep -q okay /proc/device-tree/soc/firmwarekms@7e600000/status 2> /dev/null) ; then
-  export XDG_DATA_DIRS="/usr/share/fkms:/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg"
+  export XDG_DATA_DIRS="/usr/share/fkms:${XDG_DATA_DIRS:-/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg}"
 else
-  export XDG_DATA_DIRS="/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg"
+  export XDG_DATA_DIRS="${XDG_DATA_DIRS:-/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg}"
 fi
 
 if [ -z "$XDG_CONFIG_HOME" ]; then


### PR DESCRIPTION
Flatpak installs a file to /etc/X11/Xsession.d that prepends settings to the XDG_DATA_DIRS set by the environment. However, startlxde-pi sets XDG_DATA_DIRS to a static value, deleting any other changes to the variable.

This change sets XDG_DATA_DIR to the classic value if it is not already set. The FKMS component is prepended to any existing XDG_DATA_DIR. This allows flatpak installed applications to show in the menu.

Fixes #24 