### PR TITLE
Issue #24 - Don't override XDG_DATA_DIRS

### DIFF
--- a/usr/bin/startlxde-pi
+++ b/usr/bin/startlxde-pi
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if ! grep -q 'Raspberry Pi' /proc/device-tree/model || (grep -q okay /proc/device-tree/soc/v3d@7ec00000/status 2> /dev/null || grep -q okay /proc/device-tree/soc/firmwarekms@7e600000/status 2> /dev/null || grep -q okay /proc/device-tree/v3dbus/v3d@7ec04000/status 2> /dev/null) ; then
-  export XDG_DATA_DIRS="/usr/share/fkms:/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg"
+  export XDG_DATA_DIRS="/usr/share/fkms:/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
 else
-  export XDG_DATA_DIRS="/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg"
+  export XDG_DATA_DIRS="/usr/local/share:/usr/share/raspi-ui-overrides:/usr/share:/usr/share/gdm:/var/lib/menu-xdg${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
 fi
 
 if [ -z "$XDG_CONFIG_HOME" ]; then


### PR DESCRIPTION
This replaces #23 as I address this comment https://github.com/RPi-Distro/raspberrypi-ui-mods/pull/23#issuecomment-631464345

Let me know if you have question or feedback. I'd love to get this fixed so Flatpak can work better out of the box on Raspberry Pi OS.

Close #23 
Close #24 
Close #28 (dupe of #23)